### PR TITLE
Fix 3P Exploit

### DIFF
--- a/CustomCommands/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_util.lua
@@ -166,16 +166,17 @@ hook.Add( "CalcView", "ThirdPersonView", function( ply, pos, angles, fov )
 	end
 
 end )
-
-concommand.Add( "thirdperson_toggle", toggle )
-
+net.Receive("cc_thirdperson_toggle", function(len, ply)
+		toggle()	
+	end)
 end
 
 if ( SERVER ) then
-
+util.AddNetworkString("cc_thirdperson_toggle")
 function ulx.thirdperson( calling_ply )
 
-	calling_ply:SendLua([[RunConsoleCommand("thirdperson_toggle")]])	
+	net.Start("cc_thirdperson_toggle")
+	net.Send(calling_ply)
 
 end
 local thirdperson = ulx.command( "Utility", "ulx thirdperson", ulx.thirdperson, {"!thirdperson", "!3p"}, true )

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
@@ -166,16 +166,17 @@ hook.Add( "CalcView", "ThirdPersonView", function( ply, pos, angles, fov )
 	end
 
 end )
-
-concommand.Add( "thirdperson_toggle", toggle )
-
+net.Receive("cc_thirdperson_toggle", function(len, ply)
+	toggle()	
+	end)
 end
 
 if ( SERVER ) then
-
+util.AddNetworkString("cc_thirdperson_toggle")
 function ulx.thirdperson( calling_ply )
 
-	calling_ply:SendLua([[RunConsoleCommand("thirdperson_toggle")]])	
+	net.Start("cc_thirdperson_toggle")
+ 	net.Send(calling_ply)	
 
 end
 local thirdperson = ulx.command( "Custom", "ulx thirdperson", ulx.thirdperson, {"!thirdperson", "!3p"}, true )


### PR DESCRIPTION
Fixes an exploit that lets you bypass priveledges for `ulx thirdperson` by typing `thirdperson_toggle` into console.