### PR TITLE
Fix 'ulx hide' for RCon

### DIFF
--- a/CustomCommands/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_util.lua
@@ -513,14 +513,21 @@ function ulx.hide( calling_ply, command )
 	local prevecho = GetConVarNumber( "ulx_logecho" )
 	
 	game.ConsoleCommand( "ulx logecho 0\n" )
-	
-	if strexc == false then
-		calling_ply:ConCommand( command )
+	if IsValid(calling_ply) then
+		if strexc == false then
+			calling_ply:ConCommand( command )
+		else
+			string.gsub( newstr, "ulx ", "!" )
+			calling_ply:ConCommand( newstr )
+		end
 	else
-		string.gsub( newstr, "ulx ", "!" )
-		calling_ply:ConCommand( newstr )
+		if strexc == false then
+			game.ConsoleCommand( command )
+		else
+			string.gsub( newstr, "ulx ", "!" )
+			game.ConsoleCommand( newstr )
+		end
 	end
-	
 	timer.Simple( 0.25, function()
 		game.ConsoleCommand( "ulx logecho " .. prevecho .. "\n" )
 	end )

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
@@ -528,14 +528,21 @@ function ulx.hide( calling_ply, command )
 	local prevecho = GetConVarNumber( "ulx_logecho" )
 	
 	game.ConsoleCommand( "ulx logecho 0\n" )
-	
-	if strexc == false then
-		calling_ply:ConCommand( command )
+	if IsValid(calling_ply) then
+		if strexc == false then
+			calling_ply:ConCommand( command )
+		else
+			string.gsub( newstr, "ulx ", "!" )
+			calling_ply:ConCommand( newstr )
+		end
 	else
-		string.gsub( newstr, "ulx ", "!" )
-		calling_ply:ConCommand( newstr )
+		if strexc == false then
+			game.ConsoleCommand( command )
+		else
+			string.gsub( newstr, "ulx ", "!" )
+			game.ConsoleCommand( newstr )
+		end
 	end
-	
 	timer.Simple( 0.25, function()
 		game.ConsoleCommand( "ulx logecho " .. prevecho .. "\n" )
 	end )


### PR DESCRIPTION
Currently running `ulx hide` from RCon will break logecho because it tries running `calling_ply:ConCommand(command)` which causes an error since calling_ply is nil, stopping execution so logecho won't be set to normal.