### PR TITLE
Permanent mute & gag/mute notifications

### DIFF
--- a/CustomCommands/lua/ulx/modules/sh/cc_pgag.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_pgag.lua
@@ -2,35 +2,26 @@
 --  This file holds the PGag command  --
 ----------------------------------------
 
-function ulx.pgag( calling_ply, target_plys, should_unpgag )
-
-	if should_unpgag then
-	
-		for k,v in pairs( target_plys ) do
-	
-			v:RemovePData( "permgagged" )
-			
+function ulx.pgag( calling_ply, target_plys, should_ungag )
+	if should_ungag then
+		for k,v in pairs(target_plys) do
+			v:RemovePData("permgagged")
 			v.perma_gagged = false
+			v:SetNWBool("perma_gagged", v.perma_gagged)
 		end
 		
-		ulx.fancyLogAdmin( calling_ply, "#A un-permagagged #T ", target_plys )
-		
-	elseif ( not should_unpgag ) then 
-		
-		for k,v in pairs( target_plys ) do
-	
-			v:SetPData( "permgagged", "true" )
-			
+		ulx.fancyLogAdmin(calling_ply, "#A un-permagagged #T ", target_plys)
+	else
+		for k,v in pairs(target_plys) do
+			v:SetPData("permgagged", "true")
 			v.perma_gagged = true
+			v:SetNWBool("perma_gagged", v.perma_gagged)
 		end
-	
-		ulx.fancyLogAdmin( calling_ply, "#A permanently gagged #T", target_plys )
-		
-	end
-	
 
-	
+		ulx.fancyLogAdmin(calling_ply, "#A permanently gagged #T", target_plys)
+	end
 end
+
 local pgag = ulx.command( "Chat", "ulx pgag", ulx.pgag, "!pgag" )
 pgag:addParam{ type=ULib.cmds.PlayersArg }
 pgag:addParam{ type=ULib.cmds.BoolArg, invisible=true }
@@ -43,17 +34,21 @@ pgag:setOpposite( "ulx unpgag", { _, _, true }, "!unpgag" )
 function ulx.pgagid(calling_ply, steamID, should_unpgag)
 	if should_unpgag then
 		util.RemovePData(steamID, "permgagged")
+
 		local ply = player.GetBySteamID(steamID)
 		if(ply) then
 			ply.perma_gagged = false
+			ply:SetNWBool("perma_gagged", ply.perma_gagged)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A un-permagagged #s", steamID)
 	else
 		util.SetPData(steamID, "permgagged", "true")
+
 		local ply = player.GetBySteamID(steamID)
 		if(ply) then
 			ply.perma_gagged = true
+			ply:SetNWBool("perma_gagged", ply.perma_gagged)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A permanently gagged #s", steamID)
@@ -69,85 +64,77 @@ pgagid:setOpposite("ulx unpgagid", { _, _, true }, "!unpgagid")
 
 
 
-
-local function pgagHook( listener, talker )
-
-	if talker.perma_gagged == true then
-	
-		return false
-		
-	end
-	
-end
-hook.Add( "PlayerCanHearPlayersVoice", "pdatagag", pgagHook )
-
----- functions to check if players are gagged upon them leaving and joining ----
-function pgagPlayerDisconnect( ply )
-
-	if ply:GetPData( "permgagged" ) == "true" then
-	
-		for k,v in pairs( player.GetAll() ) do
-		
-			if v:IsAdmin() then
-			
-				ULib.tsayError( v, ply:Nick() .. " has left the server and is permanently gagged." )
-				
-			end	
-			
+if SERVER then
+	hook.Remove("PlayerCanHearPlayersVoice", "CustomULXCommands_PGag_PlayerCanHearPlayersVoice")
+	hook.Add("PlayerCanHearPlayersVoice", "CustomULXCommands_PGag_PlayerCanHearPlayersVoice", function(listener, talker)
+		if talker.perma_gagged == true then
+			return false
 		end
-		
-	end
-	
+	end)
 end
-hook.Add( "PlayerDisconnected", "pgagdisconnect", pgagPlayerDisconnect )
 
-function pgaguserAuthed( ply )
-	
-	local pdata = ply:GetPData( "permgagged" )
-	
-	if  pdata == "true" then
-		
-		ply.perma_gagged = true
-		
-		for k,v in pairs( player.GetAll() ) do
-		
-			if v:IsAdmin() then
-			
-				ULib.tsayError( v, ply:Nick() .. " has joined and is permanently gagged." )
-				
+if CLIENT then
+	local lastGagNotifTime = -1
+
+	hook.Remove("PlayerStartVoice", "CustomULXCommands_PGag_PlayerStartVoice")
+	hook.Add("PlayerStartVoice", "CustomULXCommands_PGag_PlayerStartVoice", function(ply)
+		if ply:GetNWBool("perma_gagged") || ply:GetNWBool("ulx_gagged") then
+			if(lastGagNotifTime + 10 < CurTime()) then
+				ULib.csay(ply, "You are gagged. No-one can hear you!", nil, 3)
+				lastGagNotifTime = CurTime()
 			end
-			
 		end
+	end)
+end
+
+
+
+hook.Remove("PlayerDisconnected", "CustomULXCommands_PGag_PlayerDisconnected")
+hook.Add("PlayerDisconnected", "CustomULXCommands_PGag_PlayerDisconnected", function(ply)
+	if ply.perma_gagged then
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has left the server and is permanently gagged.")
+			end	
+		end
+	end
+end)
+
+
+hook.Remove("PlayerAuthed", "CustomULXCommands_PGag_PlayerConnected")
+hook.Add("PlayerAuthed", "CustomULXCommands_PGag_PlayerConnected", function(ply)
+	if ply:GetPData("permgagged") == "true" then
+		ply.perma_gagged = true
+		ply:SetNWBool("perma_gagged", ply.perma_gagged)
 		
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has joined and is permanently gagged.")
+			end
+		end
 	else 
-		
-		ply.perma_gagged = false	
-		
+		ply.perma_gagged = false
+		ply:SetNWBool("perma_gagged", ply.perma_gagged)
 	end
-	
-end
-hook.Add( "PlayerAuthed", "pgagauthed", pgaguserAuthed )
+end)
 
----- function to list players who are pgagged ----
-function ulx.printpgags( calling_ply )
 
-	pgagged = {}
+
+
+function ulx.printpgags(calling_ply)
+	local permanentlyGaggedPlayers = {}
 	
-	for k,v in pairs( player.GetAll() ) do
-	
-		if v:GetPData( "permgagged" ) == "true" then -- find all players who have "gagged" set to true
-		
-			table.insert( pgagged, v:Nick() )
-			
+	for k,v in pairs(player.GetHumans()) do
+		if v.perma_gagged then
+			table.insert(permanentlyGaggedPlayers, v:Nick())
 		end
-		
 	end
 	
-	local pgags = table.concat(  pgagged, ", " ) -- concatenate each player in the table with a comma
-	
-	ulx.fancyLog( {calling_ply}, "PGagged: #s ", pgags ) -- only prints this to the player who called the function
-	
+	local message = table.concat(permanentlyGaggedPlayers, ", ")
+	ulx.fancyLog({calling_ply}, "PGagged: #s", message)
 end
+
+
 local printpgags = ulx.command( "Chat", "ulx printpgags", ulx.printpgags, "!printpgags", true )
 printpgags:defaultAccess( ULib.ACCESS_ADMIN )
 printpgags:help("Lists any players connected to the server who are permanently gagged.")

--- a/CustomCommands/lua/ulx/modules/sh/cc_pmute.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_pmute.lua
@@ -1,0 +1,118 @@
+----------------------------------------
+--  This file holds the PMute command  --
+----------------------------------------
+
+function ulx.pmute(calling_ply, target_plys, should_unmute)
+	if should_unpmute then
+		for k,v in pairs(target_plys) do
+			v:RemovePData("permmuted")
+			v.perma_muted = false
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #T ", target_plys)
+	else
+		for k,v in pairs(target_plys) do
+			v:SetPData("permmuted", "true")
+			v.perma_muted = true
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #T", target_plys)
+	end
+end
+
+
+local pmute = ulx.command("Chat", "ulx pmute", ulx.pmute, "!pmute")
+pmute:addParam{ type=ULib.cmds.PlayersArg }
+pmute:addParam{ type=ULib.cmds.BoolArg, invisible=true }
+pmute:defaultAccess(ULib.ACCESS_ADMIN)
+pmute:help("Prevents the player from typing in chat, even after reconnecting.")
+pmute:setOpposite("ulx unpmute", { _, _, true }, "!unpmute")
+
+
+
+
+function ulx.pmuteid(calling_ply, steamID, should_unmute)
+	if should_unmute then
+		util.RemovePData(steamID, "permmuted")
+
+		local ply = player.GetBySteamID(steamID)
+		if(ply) then
+			ply.perma_muted = false
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #s", steamID)
+	else
+		util.SetPData(steamID, "permmuted", "true")
+		local ply = player.GetBySteamID(steamID)
+		if(ply) then
+			ply.perma_muted = true
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #s", steamID)
+	end
+end
+
+local pmuteid = ulx.command("Chat", "ulx pmuteid", ulx.pmuteid, "!pmuteid")
+pmuteid:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
+pmuteid:addParam{ type=ULib.cmds.BoolArg, invisible=true }
+pmuteid:defaultAccess( ULib.ACCESS_ADMIN )
+pmute:help("Prevents the player from typing in chat, even after reconnecting.")
+pmuteid:setOpposite("ulx unpmuteid", { _, _, true }, "!unpmuteid")
+
+
+
+if SERVER then
+	hook.Remove("PlayerSay", "CustomULXCommands_PMute_PlayerSay")
+	hook.Add("PlayerSay", "CustomULXCommands_PMute_PlayerSay", function(ply, text, isTeamChat)
+		if(ply.perma_muted) then return "" end
+	end)
+end
+
+
+
+hook.Remove("PlayerDisconnected", "CustomULXCommands_PMute_PlayerDisconnected")
+hook.Add("PlayerDisconnected", "CustomULXCommands_PMute_PlayerDisconnected", function(ply)
+	if ply.perma_muted then
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has left the server and is permanently muted.")
+			end
+		end
+	end
+end)
+
+
+hook.Remove("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected")
+hook.Add("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected", function(ply)
+	local isPlayerPermanentlyMuted = ply:GetPData("permmuted")
+	if isPlayerPermanentlyMuted == "true" then
+		ply.perma_muted = true
+
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has joined and is permanently muted.")
+			end
+		end
+	else
+		ply.perma_muted = false
+	end
+end)
+
+
+
+function ulx.printpmutes(calling_ply)
+	local permanentlyMutedPlayers = {}
+
+	for k,v in pairs(player.GetHumans()) do
+		if v.perma_muted then
+			table.insert(permanentlyMutedPlayers, v:Nick())
+		end
+	end
+
+	local message = table.concat(permanentlyMutedPlayers, ", ")
+	ulx.fancyLog({calling_ply}, "PMuted: #s ", message)
+end
+
+local printpmutes = ulx.command("Chat", "ulx printpmutes", ulx.printpmutes, "!printpmutes", true)
+printpmutes:defaultAccess( ULib.ACCESS_ADMIN )
+printpmutes:help("Lists any players connected to the server who are permanently muted.")

--- a/CustomCommands/lua/ulx/modules/sh/cc_pmute.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_pmute.lua
@@ -3,10 +3,11 @@
 ----------------------------------------
 
 function ulx.pmute(calling_ply, target_plys, should_unmute)
-	if should_unpmute then
+	if should_unmute then
 		for k,v in pairs(target_plys) do
 			v:RemovePData("permmuted")
 			v.perma_muted = false
+			v:SetNWBool("perma_muted", v.perma_muted)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #T ", target_plys)
@@ -14,6 +15,7 @@ function ulx.pmute(calling_ply, target_plys, should_unmute)
 		for k,v in pairs(target_plys) do
 			v:SetPData("permmuted", "true")
 			v.perma_muted = true
+			v:SetNWBool("perma_muted", v.perma_muted)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #T", target_plys)
@@ -38,14 +40,17 @@ function ulx.pmuteid(calling_ply, steamID, should_unmute)
 		local ply = player.GetBySteamID(steamID)
 		if(ply) then
 			ply.perma_muted = false
+			ply:SetNWBool("perma_muted", ply.perma_muted)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #s", steamID)
 	else
 		util.SetPData(steamID, "permmuted", "true")
+
 		local ply = player.GetBySteamID(steamID)
 		if(ply) then
 			ply.perma_muted = true
+			ply:SetNWBool("perma_muted", ply.perma_muted)
 		end
 
 		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #s", steamID)
@@ -64,7 +69,18 @@ pmuteid:setOpposite("ulx unpmuteid", { _, _, true }, "!unpmuteid")
 if SERVER then
 	hook.Remove("PlayerSay", "CustomULXCommands_PMute_PlayerSay")
 	hook.Add("PlayerSay", "CustomULXCommands_PMute_PlayerSay", function(ply, text, isTeamChat)
-		if(ply.perma_muted) then return "" end
+		if(ply:GetNWBool("ulx_muted") || ply.perma_muted) then
+			local lastMuteNotifTime = ply.lastMuteNotifTime or -1
+
+			if(lastMuteNotifTime + 10 < CurTime()) then
+				ULib.tsay(ply, "You are muted. No-one can see your messages!")
+				ply.lastMuteNotifTime = CurTime()
+			end
+		end
+
+		if(ply.perma_muted) then
+			return ""
+		end
 	end)
 end
 
@@ -84,9 +100,9 @@ end)
 
 hook.Remove("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected")
 hook.Add("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected", function(ply)
-	local isPlayerPermanentlyMuted = ply:GetPData("permmuted")
-	if isPlayerPermanentlyMuted == "true" then
+	if ply:GetPData("permmuted") == "true" then
 		ply.perma_muted = true
+		ply:SetNWBool("perma_muted", ply.perma_muted)
 
 		for k,v in pairs(player.GetHumans()) do
 			if v:IsAdmin() then
@@ -95,6 +111,7 @@ hook.Add("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected", function(ply
 		end
 	else
 		ply.perma_muted = false
+		ply:SetNWBool("perma_muted", ply.perma_muted)
 	end
 end)
 
@@ -110,7 +127,7 @@ function ulx.printpmutes(calling_ply)
 	end
 
 	local message = table.concat(permanentlyMutedPlayers, ", ")
-	ulx.fancyLog({calling_ply}, "PMuted: #s ", message)
+	ulx.fancyLog({calling_ply}, "PMuted: #s", message)
 end
 
 local printpmutes = ulx.command("Chat", "ulx printpmutes", ulx.printpmutes, "!printpmutes", true)

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_pmute.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_pmute.lua
@@ -1,0 +1,118 @@
+----------------------------------------
+--  This file holds the PMute command  --
+----------------------------------------
+
+function ulx.pmute(calling_ply, target_plys, should_unmute)
+	if should_unpmute then
+		for k,v in pairs(target_plys) do
+			v:RemovePData("permmuted")
+			v.perma_muted = false
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #T ", target_plys)
+	else
+		for k,v in pairs(target_plys) do
+			v:SetPData("permmuted", "true")
+			v.perma_muted = true
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #T", target_plys)
+	end
+end
+
+
+local pmute = ulx.command("Custom", "ulx pmute", ulx.pmute, "!pmute")
+pmute:addParam{ type=ULib.cmds.PlayersArg }
+pmute:addParam{ type=ULib.cmds.BoolArg, invisible=true }
+pmute:defaultAccess(ULib.ACCESS_ADMIN)
+pmute:help("Prevents the player from typing in chat, even after reconnecting.")
+pmute:setOpposite("ulx unpmute", { _, _, true }, "!unpmute")
+
+
+
+
+function ulx.pmuteid(calling_ply, steamID, should_unmute)
+	if should_unmute then
+		util.RemovePData(steamID, "permmuted")
+
+		local ply = player.GetBySteamID(steamID)
+		if(ply) then
+			ply.perma_muted = false
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A removed the permanent mute for #s", steamID)
+	else
+		util.SetPData(steamID, "permmuted", "true")
+		local ply = player.GetBySteamID(steamID)
+		if(ply) then
+			ply.perma_muted = true
+		end
+
+		ulx.fancyLogAdmin(calling_ply, "#A permanently muted #s", steamID)
+	end
+end
+
+local pmuteid = ulx.command("Custom", "ulx pmuteid", ulx.pmuteid, "!pmuteid")
+pmuteid:addParam{ type=ULib.cmds.StringArg, hint="steamid" }
+pmuteid:addParam{ type=ULib.cmds.BoolArg, invisible=true }
+pmuteid:defaultAccess( ULib.ACCESS_ADMIN )
+pmute:help("Prevents the player from typing in chat, even after reconnecting.")
+pmuteid:setOpposite("ulx unpmuteid", { _, _, true }, "!unpmuteid")
+
+
+
+if SERVER then
+	hook.Remove("PlayerSay", "CustomULXCommands_PMute_PlayerSay")
+	hook.Add("PlayerSay", "CustomULXCommands_PMute_PlayerSay", function(ply, text, isTeamChat)
+		if(ply.perma_muted) then return "" end
+	end)
+end
+
+
+
+hook.Remove("PlayerDisconnected", "CustomULXCommands_PMute_PlayerDisconnected")
+hook.Add("PlayerDisconnected", "CustomULXCommands_PMute_PlayerDisconnected", function(ply)
+	if ply.perma_muted then
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has left the server and is permanently muted.")
+			end
+		end
+	end
+end)
+
+
+hook.Remove("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected")
+hook.Add("PlayerAuthed", "CustomULXCommands_PMute_PlayerConnected", function(ply)
+	local isPlayerPermanentlyMuted = ply:GetPData("permmuted")
+	if isPlayerPermanentlyMuted == "true" then
+		ply.perma_muted = true
+
+		for k,v in pairs(player.GetHumans()) do
+			if v:IsAdmin() then
+				ULib.tsayError(v, ply:Nick() .. " has joined and is permanently muted.")
+			end
+		end
+	else
+		ply.perma_muted = false
+	end
+end)
+
+
+
+function ulx.printpmutes(calling_ply)
+	local permanentlyMutedPlayers = {}
+
+	for k,v in pairs(player.GetHumans()) do
+		if v.perma_muted then
+			table.insert(permanentlyMutedPlayers, v:Nick())
+		end
+	end
+
+	local message = table.concat(permanentlyMutedPlayers, ", ")
+	ulx.fancyLog({calling_ply}, "PMuted: #s ", message)
+end
+
+local printpmutes = ulx.command("Custom", "ulx printpmutes", ulx.printpmutes, "!printpmutes", true)
+printpmutes:defaultAccess( ULib.ACCESS_ADMIN )
+printpmutes:help("Lists any players connected to the server who are permanently muted.")


### PR DESCRIPTION
* Adds `!pmute`/`!unpmute` - Permanently mute a player, so that if the player rejoins, they remain muted
* Adds `!pmuteid`/`!unpmuteid` - Permanently mute a player using their Steam ID, so that offline players can be muted
* Adds `!printpmutes` - Lists permanently muted players
* Adds notifications for gagged/muted players
    * If a player is muted/permanently muted and they try to send a message, they will see `"You are muted. No-one can see your messages!"` in chat
    * If a player is gagged/permanently gagged and they try to use voice chat, they will see `"You are gagged. No-one can hear you!"` in the middle of their screen

![preview](https://cdn.discordapp.com/attachments/318595912941436930/714905223516389436/unknown.png)

---

This should be my last pull request for now.
If you have anything you'd like done on this project, or have any issues raised, feel free to tag me as I may be able to help