### PR TITLE
Adds search functionality to watchlist

### DIFF
--- a/CustomCommands/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_util.lua
@@ -1021,7 +1021,7 @@ if ( SERVER ) then
 		for k, otherPlayer in pairs( player.GetHumans()) do
 			if otherPlayer:IsAdmin() then
 				ULib.tsayError(otherPlayer, ply:Nick() .. " (" .. ply:SteamID() .. ") has joined the server and is on the watchlist!" )
-				ULib.tsayError(otherPlayer, "Reason: " .. watchlistInfo.Reason)
+				ULib.tsayColor(otherPlayer, "", Color(255, 141, 34), "Reason: ", Color(255, 0, 0), watchlistInfo.Reason)
 			end
 		end
 	end)

--- a/CustomCommands/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands/lua/ulx/modules/sh/cc_util.lua
@@ -943,6 +943,21 @@ if ( SERVER ) then
 			return file.Exists(WatchlistData.GetFilePath(steamID), "DATA")
 		end,
 
+		GetPlayerWatchlistInfo = function(steamID)
+			if(not WatchlistData.IsPlayerOnWatchlist(steamID)) then return nil end
+
+			local watchInfoRaw = file.Read(WatchlistData.GetFilePath(steamID), "DATA")
+			local watchInfo = string.Explode("\n", watchInfoRaw)
+
+			return {
+				SteamID = steamID:upper(),
+				PlayerName = watchInfo[1],
+				AdminName = watchInfo[2],
+				Reason = watchInfo[3],
+				DateTime = watchInfo[4]
+			}
+		end,
+
 		RemovePlayer = function(steamID)
 			file.Delete(WatchlistData.GetFilePath(steamID))
 		end,
@@ -1000,11 +1015,13 @@ if ( SERVER ) then
 	end)
 	
 	hook.Add("PlayerInitialSpawn", "CheckWatchedPlayers", function(ply)
-		if(WatchlistData.IsPlayerOnWatchlist(ply:SteamID()) == false) then return end
+		local watchlistInfo = WatchlistData.GetPlayerWatchlistInfo(ply:SteamID())
+		if(watchlistInfo == nil) then return end
 
 		for k, otherPlayer in pairs( player.GetHumans()) do
 			if otherPlayer:IsAdmin() then
 				ULib.tsayError(otherPlayer, ply:Nick() .. " (" .. ply:SteamID() .. ") has joined the server and is on the watchlist!" )
+				ULib.tsayError(otherPlayer, "Reason: " .. watchlistInfo.Reason)
 			end
 		end
 	end)

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
@@ -1037,7 +1037,7 @@ if ( SERVER ) then
 		for k, otherPlayer in pairs( player.GetHumans()) do
 			if otherPlayer:IsAdmin() then
 				ULib.tsayError(otherPlayer, ply:Nick() .. " (" .. ply:SteamID() .. ") has joined the server and is on the watchlist!" )
-				ULib.tsayError(otherPlayer, "Reason: " .. watchlistInfo.Reason)
+				ULib.tsayColor(otherPlayer, Color(255, 141, 34), "Reason: ", Color(255, 0, 0), watchlistInfo.Reason)
 			end
 		end
 	end)

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
@@ -1094,29 +1094,48 @@ watchlist:help( "View the watchlist" )
 
 
 if ( CLIENT ) then
+	function debounce(func, wait)
+		local timerName
+
+		return function(...)
+			local args = ...
+			local later = function()
+				timerName = nil
+				func(args)
+			end
+
+			if(timerName != nil) then timer.Remove(timerName) end
+			timerName = tostring(func) .. tostring(math.random(1, 9999999))
+			timer.Create(timerName, wait, 1, later)
+		end
+	end
 
 	local WatchlistUIList = nil
+	local WatchlistData = {}
+
+	local function UpdateWatchlistUIList(watchedPlayersList)
+		if(WatchlistUIList == nil) then return end
+
+		WatchlistUIList:Clear()
+
+		for k, watchedPlayer in pairs(watchedPlayersList) do
+			WatchlistUIList:AddLine(watchedPlayer.SteamID, watchedPlayer.PlayerName, watchedPlayer.AdminName, watchedPlayer.Reason, watchedPlayer.DateTime)
+		end
+	end
 	
 	net.Receive("Watchlist_RequestWatchedPlayersCallback", function()
 		local length = net.ReadUInt(32)
 		local dataCompressed = net.ReadData(length)
 
-		local watchedPlayers = util.JSONToTable(util.Decompress(dataCompressed))
-
-		if(WatchlistUIList != nil) then
-			WatchlistUIList:Clear()
-
-			for k, watchedPlayer in pairs(watchedPlayers) do
-				WatchlistUIList:AddLine(watchedPlayer.SteamID, watchedPlayer.PlayerName, watchedPlayer.AdminName, watchedPlayer.Reason, watchedPlayer.DateTime)
-			end
-		end
+		WatchlistData = util.JSONToTable(util.Decompress(dataCompressed))
+		UpdateWatchlistUIList(WatchlistData)
 	end)
 
 
 	local function RenderWatchlist()
 		local main = vgui.Create( "DFrame" )	
 			main:SetPos( 50,50 )
-			main:SetSize( 700, 400 )
+			main:SetSize( 700, 425 )
 			main:SetTitle( "Watchlist" )
 			main:SetVisible( true )
 			main:SetDraggable( true )
@@ -1128,8 +1147,42 @@ if ( CLIENT ) then
 			WatchlistUIList = nil
 		end
 
+
+		local searchBox = vgui.Create("DTextEntry", main)
+		searchBox:SetPos(4, 27)
+		searchBox:SetSize(300, 25)
+		searchBox:SetPlaceholderText("Search...")
+		searchBox:SetValue("")
+
+		searchBox:SetUpdateOnType(true)
+		searchBox.OnValueChange = debounce(function(self)
+			local searchTerm = string.lower(string.sub(self:GetValue(), 1, 200))
+
+			if(searchTerm == "") then
+				UpdateWatchlistUIList(WatchlistData)
+				return
+			end
+
+
+			local searchResults = {}
+			for k, watchedPlayer in pairs(WatchlistData) do
+				if(string.find(watchedPlayer.SteamID:lower(), searchTerm) != nil) then
+					table.insert(searchResults, watchedPlayer)
+				elseif(string.find(watchedPlayer.PlayerName:lower(), searchTerm) != nil) then
+					table.insert(searchResults, watchedPlayer)
+				elseif(string.find(watchedPlayer.Reason:lower(), searchTerm) != nil) then
+					table.insert(searchResults, watchedPlayer)
+				elseif(string.find(watchedPlayer.AdminName:lower(), searchTerm) != nil) then
+					table.insert(searchResults, watchedPlayer)
+				end
+			end
+
+			UpdateWatchlistUIList(searchResults)
+		end, 0.5)
+
+
 		WatchlistUIList = vgui.Create( "DListView", main )
-			WatchlistUIList:SetPos( 4, 27 )
+			WatchlistUIList:SetPos( 4, 52 )
 			WatchlistUIList:SetSize( 692, 369 )
 			WatchlistUIList:SetMultiSelect( false )
 			WatchlistUIList:AddColumn( "SteamID" )

--- a/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
+++ b/CustomCommands_onecategory/lua/ulx/modules/sh/cc_util.lua
@@ -959,6 +959,21 @@ if ( SERVER ) then
 			return file.Exists(WatchlistData.GetFilePath(steamID), "DATA")
 		end,
 
+		GetPlayerWatchlistInfo = function(steamID)
+			if(not WatchlistData.IsPlayerOnWatchlist(steamID)) then return nil end
+
+			local watchInfoRaw = file.Read(WatchlistData.GetFilePath(steamID), "DATA")
+			local watchInfo = string.Explode("\n", watchInfoRaw)
+
+			return {
+				SteamID = steamID:upper(),
+				PlayerName = watchInfo[1],
+				AdminName = watchInfo[2],
+				Reason = watchInfo[3],
+				DateTime = watchInfo[4]
+			}
+		end,
+
 		RemovePlayer = function(steamID)
 			file.Delete(WatchlistData.GetFilePath(steamID))
 		end,
@@ -1016,11 +1031,13 @@ if ( SERVER ) then
 	end)
 	
 	hook.Add("PlayerInitialSpawn", "CheckWatchedPlayers", function(ply)
-		if(WatchlistData.IsPlayerOnWatchlist(ply:SteamID()) == false) then return end
+		local watchlistInfo = WatchlistData.GetPlayerWatchlistInfo(ply:SteamID())
+		if(watchlistInfo == nil) then return end
 
 		for k, otherPlayer in pairs( player.GetHumans()) do
 			if otherPlayer:IsAdmin() then
 				ULib.tsayError(otherPlayer, ply:Nick() .. " (" .. ply:SteamID() .. ") has joined the server and is on the watchlist!" )
+				ULib.tsayError(otherPlayer, "Reason: " .. watchlistInfo.Reason)
 			end
 		end
 	end)


### PR DESCRIPTION
# Watchlist search functionality
* Allows admin to search the watchlist by Steam ID, player name, admin name and reason
* Preview video - https://youtu.be/ztkYmyEz4Ck

# Watchlist join message
This change also prints out the reason why a player is on the watchlist when they join
![preview](https://cdn.discordapp.com/attachments/318595912941436930/803016973877116958/unknown.png)

I opened this PR a bit too early, so I still need to test it some more.